### PR TITLE
Feature/lcd datasheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@ __pycache__/
 
 # Distribution Dir
 dist/
+
+# macOS metadata
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+.fseventsd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ All notable changes to WeeWX-JSON will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.4] - 2026-02-05
 - Added new `lcd_datasheet.json` output template for NOAA-style layered reporting.
 - Included 15-minute raw captures for daily rows in `lcd_datasheet.json`.
 - Added aggregated summaries to limit file growth: weekly/monthly daily summaries and yearly monthly summaries.
 - Updated `skin.conf` to generate `lcd_datasheet.json` without changing existing `weewx.json` or `current_minimal.json`.
-- Updated `README.md` generated-file documentation for the new output.
+- Updated `README.md` with new output details, report regeneration, and packaging guidance.
+- Updated installer template to register the extension as `weewx-json`.
+- Ignored macOS metadata files in `.gitignore`.
 
 ## [1.3] - 2024-10-30
 - Fixed template comparisons to avoid literal-comparison warnings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,34 @@
-Upcoming
---------
+# Changelog
+All notable changes to WeeWX-JSON will be documented in this file.
 
-*   Fixed a warning due to the use of `is` comparison with a literal instead of `==`
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-1.2
----
+## [Unreleased]
+- Added new `lcd_datasheet.json` output template for NOAA-style layered reporting.
+- Included 15-minute raw captures for daily rows in `lcd_datasheet.json`.
+- Added aggregated summaries to limit file growth: weekly/monthly daily summaries and yearly monthly summaries.
+- Updated `skin.conf` to generate `lcd_datasheet.json` without changing existing `weewx.json` or `current_minimal.json`.
+- Updated `README.md` generated-file documentation for the new output.
 
-*   Using ISO8601 for the default timestamp format. For existing functionality change the `timestamp_fmt` option to
-    `human`. 
+## [1.3] - 2024-10-30
+- Fixed template comparisons to avoid literal-comparison warnings.
+- Updated GitHub Actions steps (`checkout`, `upload-artifact`) in the packaging workflow.
+- Logged the release in this changelog.
 
-1.1
----
+## [1.2] - 2024-01-01
+- Added automated package build support (`build_package.py`) and GitHub Actions packaging workflow.
+- Added distributable install template at `dist-template/install.py.template`.
+- Switched default timestamp output to ISO8601 in JSON templates and skin config.
+- Renamed `changelog` to `CHANGELOG.md` and recorded the 1.2 release notes.
 
-*   Smaller JSON file to be generated, `current_minimal.json`. No computed or archived values.
+## [1.1] - 2020-10-07
+- Added `current_minimal.json.tmpl` for a smaller output with no computed or archived values.
+- Updated `skin.conf` and installer file lists to include the minimal JSON template.
+- Expanded docs with install/uninstall details and example output.
+- Included critical measurement updates and syntax fixes from PR #2.
 
-1.0 
----
-
-*   Pulled the JSON template in from the failed pull request
+## [1.0] - 2020-10-03
+- Initial extension release from imported prior work.
+- Added extension packaging/install support (`install.py`) and `skins/JSON/skin.conf`.
+- Included baseline project description and repository scaffolding.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,49 @@
 # WeeWX-JSON
-Extension for JSON output from WeeWX
+Extension for JSON output from WeeWX 5.2
 
-This extension provides a skin that is not designed to be used from a web browser, rather for consumption from another
-type of client...smartphone app, dynamic javascript page, automated bot.
+This extension provides a skin intended for non-browser clients such as smartphone apps, dynamic JavaScript pages,
+or automated bots.
 
-This is most of the same data that can be found in the default "Seasons" report's `rss.xml` output, but formatted in
-the JSON format for easier consumption by clients.
+It mirrors most of the data found in the default "Seasons" report `rss.xml` while adding JSON outputs tailored for
+automation, including NOAA-style layered reporting with 15-minute captures and aggregated daily/monthly summaries.
 
 
 ## Installing
 
-Download the latest release from the [github releases](https://github.com/open-astro/WeeWX-JSON/releases) page
+Download the latest release from the [github releases](https://github.com/open-astro/weewx-json/releases) page
 
-Run `weectl extension install WeeWX-JSON_X.X.tar.gz`
+Run `weectl extension install weewx-json_X.X.tar.gz`
 
 This will automatically add a `[[JSONReport]]` to your weewx.conf file that will include the `weewx.json` in your 
 `HTML_ROOT`. 
+
+To regenerate reports from existing archive data, you can run:
+
+```sh
+sudo weectl report run
+```
+
+## Packaging local changes
+
+If you are modifying the extension locally, use the packaging script to ensure `install.py` is included at the
+top level of the archive:
+
+```sh
+python3 build_package.py --set-version 1.4
+```
+
+This creates `dist/weewx-json_1.4.tar.gz`, which you can install with `weectl extension install`.
+
+On macOS, confirm you copied the `dist` tarball (not a repo archive) before installing on Linux:
+
+```sh
+tar -tzf dist/weewx-json_1.4.tar.gz | head
+```
+
+You should see `weewx-json_1.4/install.py` at the top level.
+
+If you prefer to build the tarball manually, make sure it contains `install.py` at the top level (not the repo root),
+or the install will fail.
 
 ## Generated files
 
@@ -25,7 +53,7 @@ This will automatically add a `[[JSONReport]]` to your weewx.conf file that will
 
 ## Uninstalling
 
-Run `weectl extension uninstall WeeWX-JSON`
+Run `weectl extension uninstall weewx-json`
 
 ## Example Output
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# weewx-json
-Extension for JSON output from weewx
+# WeeWX-JSON
+Extension for JSON output from WeeWX
 
 This extension provides a skin that is not designed to be used from a web browser, rather for consumption from another
 type of client...smartphone app, dynamic javascript page, automated bot.
@@ -10,16 +10,22 @@ the JSON format for easier consumption by clients.
 
 ## Installing
 
-Download the latest release from the [github releases](https://github.com/teeks99/weewx-json/releases) page
+Download the latest release from the [github releases](https://github.com/open-astro/WeeWX-JSON/releases) page
 
-Run `wee_extension --install=weewx-json_X.X.tar.gz`
+Run `weectl extension install WeeWX-JSON_X.X.tar.gz`
 
 This will automatically add a `[[JSONReport]]` to your weewx.conf file that will include the `weewx.json` in your 
 `HTML_ROOT`. 
 
+## Generated files
+
+- `weewx.json`: full current + period min/max summary output
+- `current_minimal.json`: compact current conditions
+- `lcd_datasheet.json`: NOAA-style layered output (daily 15-minute captures + weekly/monthly daily summaries + yearly monthly summaries)
+
 ## Uninstalling
 
-Run `wee_extension --uninstall=weewx-json`
+Run `weectl extension uninstall WeeWX-JSON`
 
 ## Example Output
 

--- a/build_package.py
+++ b/build_package.py
@@ -4,7 +4,7 @@ import shutil
 import argparse
 import tarfile
 
-version = "0.0"
+version = "1.4"
 dist_path = "dist"
 
 def package_dir():

--- a/dist-template/install.py.template
+++ b/dist-template/install.py.template
@@ -7,10 +7,10 @@ class JSON_Installer(ExtensionInstaller):
     def __init__(self):
         super(JSON_Installer, self).__init__(
             version="$version",
-            name='JSON',
+            name='weewx-json',
             description='Add JSON output',
-            author="Thomas Kent",
-            author_email="https://github.com/teeks99/weewx-json",
+            author="Joey Troy",
+            author_email="https://github.com/open-astro/weewx-json",
             config={
                 'StdReport': {
                     'JSONReport': {

--- a/skins/JSON/lcd_datasheet.json.tmpl
+++ b/skins/JSON/lcd_datasheet.json.tmpl
@@ -1,0 +1,172 @@
+{
+    "station":
+    {
+        "location": "$station.location",
+        "latitude": $station.stn_info.latitude_f,
+        "longitude": $station.stn_info.longitude_f,
+        "altitude_meters": $station.altitude.meter.raw,
+        "link": "$station.station_url"
+    },
+    "generation":
+    {
+        #if $Extras.timestamp_fmt == "human"
+        "time": "$current.dateTime.format("%a, %d %b %Y %H:%M:%S %Z")",
+        #else
+        "time": "$current.dateTime.format("%Y-%m-%dT%H:%M:%S%z")",
+        #end if
+        "generator": "weewx $station.version"
+    },
+    "lcd_datasheet":
+    {
+        "daily_captures":
+        {
+            "interval_minutes": 15,
+            "fields": [
+                "timestamp_epoch",
+                "temperature",
+                "wind_direction",
+                "wind_speed",
+                "wind_gust",
+                "rain",
+                "rain_rate",
+                "humidity",
+                "barometer"
+            ],
+            "rows":
+            [
+                #set $first = 1
+                #for $row in $day.records
+                #if not $first
+                ,
+                #end if
+                [
+                    $row.dateTime.raw,
+                    $row.outTemp.raw,
+                    $row.windDir.raw,
+                    $row.windSpeed.raw,
+                    $row.windGust.raw,
+                    $row.rain.raw,
+                    $row.rainRate.raw,
+                    $row.outHumidity.raw,
+                    $row.barometer.raw
+                ]
+                #set $first = 0
+                #end for
+            ]
+        },
+        "weekly_daily_summaries":
+        [
+            #set $first = 1
+            #for $week_day in $week.days
+            #if not $first
+            ,
+            #end if
+            {
+                "period_start_epoch": $week_day.start.raw,
+                "period_end_epoch": $week_day.end.raw,
+                "temperature": {
+                    "min": $week_day.outTemp.min.raw,
+                    "max": $week_day.outTemp.max.raw,
+                    "avg": $week_day.outTemp.avg.raw
+                },
+                "humidity": {
+                    "min": $week_day.outHumidity.min.raw,
+                    "max": $week_day.outHumidity.max.raw,
+                    "avg": $week_day.outHumidity.avg.raw
+                },
+                "wind": {
+                    "speed_avg": $week_day.windSpeed.avg.raw,
+                    "speed_max": $week_day.windSpeed.max.raw,
+                    "gust_max": $week_day.windGust.max.raw
+                },
+                "barometer": {
+                    "min": $week_day.barometer.min.raw,
+                    "max": $week_day.barometer.max.raw,
+                    "avg": $week_day.barometer.avg.raw
+                },
+                "rain": {
+                    "total": $week_day.rain.sum.raw,
+                    "rate_max": $week_day.rainRate.max.raw
+                }
+            }
+            #set $first = 0
+            #end for
+        ],
+        "monthly_daily_summaries":
+        [
+            #set $first = 1
+            #for $month_day in $month.days
+            #if not $first
+            ,
+            #end if
+            {
+                "period_start_epoch": $month_day.start.raw,
+                "period_end_epoch": $month_day.end.raw,
+                "temperature": {
+                    "min": $month_day.outTemp.min.raw,
+                    "max": $month_day.outTemp.max.raw,
+                    "avg": $month_day.outTemp.avg.raw
+                },
+                "humidity": {
+                    "min": $month_day.outHumidity.min.raw,
+                    "max": $month_day.outHumidity.max.raw,
+                    "avg": $month_day.outHumidity.avg.raw
+                },
+                "wind": {
+                    "speed_avg": $month_day.windSpeed.avg.raw,
+                    "speed_max": $month_day.windSpeed.max.raw,
+                    "gust_max": $month_day.windGust.max.raw
+                },
+                "barometer": {
+                    "min": $month_day.barometer.min.raw,
+                    "max": $month_day.barometer.max.raw,
+                    "avg": $month_day.barometer.avg.raw
+                },
+                "rain": {
+                    "total": $month_day.rain.sum.raw,
+                    "rate_max": $month_day.rainRate.max.raw
+                }
+            }
+            #set $first = 0
+            #end for
+        ],
+        "yearly_monthly_summaries":
+        [
+            #set $first = 1
+            #for $year_month in $year.months
+            #if not $first
+            ,
+            #end if
+            {
+                "period_start_epoch": $year_month.start.raw,
+                "period_end_epoch": $year_month.end.raw,
+                "temperature": {
+                    "min": $year_month.outTemp.min.raw,
+                    "max": $year_month.outTemp.max.raw,
+                    "avg": $year_month.outTemp.avg.raw
+                },
+                "humidity": {
+                    "min": $year_month.outHumidity.min.raw,
+                    "max": $year_month.outHumidity.max.raw,
+                    "avg": $year_month.outHumidity.avg.raw
+                },
+                "wind": {
+                    "speed_avg": $year_month.windSpeed.avg.raw,
+                    "speed_max": $year_month.windSpeed.max.raw,
+                    "gust_max": $year_month.windGust.max.raw
+                },
+                "barometer": {
+                    "min": $year_month.barometer.min.raw,
+                    "max": $year_month.barometer.max.raw,
+                    "avg": $year_month.barometer.avg.raw
+                },
+                "rain": {
+                    "total": $year_month.rain.sum.raw,
+                    "rate_max": $year_month.rainRate.max.raw
+                }
+            }
+            #set $first = 0
+            #end for
+        ]
+    }
+}

--- a/skins/JSON/skin.conf
+++ b/skins/JSON/skin.conf
@@ -19,6 +19,9 @@
         [[minimal]]
             template = current_minimal.json.tmpl
 
+        [[lcd_datasheet]]
+            template = lcd_datasheet.json.tmpl
+
 [Generators]
         # The list of generators that are to be run:
         generator_list = weewx.cheetahgenerator.CheetahGenerator


### PR DESCRIPTION
## Summary
- Release 1.4 with NOAA-style `lcd_datasheet.json` output and expanded aggregation support.
- Fix extension naming so `weectl` installs/uninstalls as `weewx-json`.
- Update README packaging and regeneration guidance; add macOS metadata ignores.

## Test plan
- Built package via `python3 build_package.py --set-version 1.4`
- Verified tarball contains `weewx-json_1.4/install.py` at top level
- Installed on WeeWX and ran `weectl report run` to regenerate outputs